### PR TITLE
Change action bar layout to have action-bar-title

### DIFF
--- a/blank/blank.component.html
+++ b/blank/blank.component.html
@@ -1,4 +1,5 @@
-<ActionBar title="Home" class="action-bar">
+<ActionBar class="action-bar">
+    <Label class="action-bar-title" text="Home"></Label>
 </ActionBar>
 
 <StackLayout class="page">

--- a/login/login.component.html
+++ b/login/login.component.html
@@ -1,4 +1,5 @@
-<ActionBar title="Login" class="action-bar">
+<ActionBar class="action-bar">
+    <Label class="action-bar-title" text="Login"></Label>
 </ActionBar>
 <ScrollView>
     <StackLayout class="page p-t-15">

--- a/signup/signup.component.html
+++ b/signup/signup.component.html
@@ -1,4 +1,5 @@
-<ActionBar title="Sign up" class="action-bar">
+<ActionBar class="action-bar">
+    <Label class="action-bar-title" text="Sign up"></Label>
 </ActionBar>
 <ScrollView>
     <StackLayout class="page p-t-15">


### PR DESCRIPTION
Change action bar layout to use the same layout as the other templates. In this way the page title will be always center. Otherwise once will be center, another time - left